### PR TITLE
feat: use serverless.tf modules

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,17 +9,11 @@ output "lambda_bucket_name" {
 output "function_name" {
   description = "Name of the Lambda function."
 
-  value = aws_lambda_function.hey_joe.function_name
+  value = module.lambda_function.lambda_function_name
 }
 
 output "base_url" {
   description = "Base URL for API Gateway stage."
 
-  value = aws_apigatewayv2_stage.lambda.invoke_url
-}
-
-output "log_group_name" {
-  description = "Log group name for inspection / tailing."
-
-  value = aws_cloudwatch_log_group.hey_joe.name
+  value = module.api_gateway.default_apigatewayv2_stage_invoke_url
 }


### PR DESCRIPTION
This replaces the raw aws resources with community created modules. The s3 bucket can likely also be replaced with a module. That brings the whole app down to an s3 bucket, lambda, and api gateway modules.